### PR TITLE
Change the control action

### DIFF
--- a/templates/SilverStripe/Security/Security_MultiAuthenticatorTabbedForms.ss
+++ b/templates/SilverStripe/Security/Security_MultiAuthenticatorTabbedForms.ss
@@ -2,13 +2,13 @@
     <ul class="nav nav-tabs" role="tablist">
         <% loop $Forms %>
         <li role="presentation" <% if Pos = 1 %>class="active"<% end_if %>>
-            <a href="#{$FormName}" aria-controls="{$FormName}" role="tab" data-toggle="tab">$AuthenticatorName</a>
+            <a href="#form_{$Pos}" aria-controls="form_{$Pos}" role="tab" data-toggle="tab">$AuthenticatorName</a>
         </li>
         <% end_loop %>
     </ul>
     <div class="tab-content">
         <% loop $Forms %>
-        <div role="tabpanel" class="tab-pane fade <% if Pos = 1 %>in active <% end_if %>" id="{$FormName}">
+        <div role="tabpanel" class="tab-pane fade <% if Pos = 1 %>in active <% end_if %>" id="form_{$Pos}">
             <h3>$AuthenticatorName</h3>
             $forTemplate
         </div>


### PR DESCRIPTION
When the forms have the same action (which is defined by the `FormName`), the forms don't tab properly anymore. By using the `$Pos` variable, the tabset tabs again